### PR TITLE
Allow set of prometheus collector addr as env var

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,2 +1,3 @@
 Guillaume Gauvrit <guillaume@gandi.net>
 Michael Vieira <michael.vieira@gandi.net>
+Andrew Gershman <andrew.j.gershman@gmail.com>

--- a/src/celery_prometheus/prometheus_bootstep.py
+++ b/src/celery_prometheus/prometheus_bootstep.py
@@ -1,5 +1,6 @@
 """Helper for celery."""
 import logging
+import os
 from argparse import ArgumentParser
 from typing import Any, Mapping, Optional, cast
 
@@ -26,7 +27,11 @@ def add_prometheus_option(app: Celery) -> None:
     if celery_version.major < 5:
 
         def add_preload_arguments(parser: ArgumentParser) -> None:
-            parser.add_argument("--prometheus-collector-addr", default=None, help=help)
+            parser.add_argument(
+                "--prometheus-collector-addr",
+                default=os.getenv("CELERY_PROMETHEUS_COLLECTOR_ADDR"),
+                help=help,
+            )
 
         app.user_options["preload"].add(add_preload_arguments)
     else:


### PR DESCRIPTION
Looking to allow setting of the prometheus collector address string as an environment variable. This is useful in certain contexts where configuration is more environment variable driven than command and argument driven.